### PR TITLE
Integration

### DIFF
--- a/MIT.md
+++ b/MIT.md
@@ -1,0 +1,7 @@
+Copyright 2023, Davian Beroni, Iqbal Elham and Ric Martínez
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this project and associated documentation files, to deal in the project without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the project, and to permit persons to whom the project is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the project.
+
+THE project IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE project OR THE USE OR OTHER DEALINGS IN THE project.

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@
 <details>
   <summary>Server</summary>
   <ul>
-    <li><a href="https://expressjs.com/">Ruby on rails</a></li>
+    <li><a href="https://rubyonrails.org/">Ruby on rails</a></li>
   </ul>
 </details>
 
@@ -150,6 +150,11 @@ To run tests on the views, run the following command:
 - GitHub: [dadadon](https://github.com/dadadon)
 - Twitter: [Davian Beroni](https://twitter.com/davianberoni)
 - LinkedIn: [Davian Beroni](https://www.linkedin.com/in/davian-beroni/)
+
+👤 **Iqbal Elham**
+
+- GitHub: [dadadon](https://github.com/iqbal-elham)
+- LinkedIn: [Davian Beroni](https://www.linkedin.com/in/iqbal-elham/)
 
 <p align="right">(<a href="#readme-top">back to top</a>)</p>
 

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -35,7 +35,7 @@
   border: 2px solid #000;
   width: 70%;
   justify-content: space-between;
-  height:auto;
+  height: auto;
 }
 
 .post-preview {

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -33,7 +33,9 @@
   display: flex;
   gap: 45px;
   border: 2px solid #000;
-  width: 50%;
+  width: 70%;
+  justify-content: space-between;
+  height: fit-content;
 }
 
 .post-preview {
@@ -53,4 +55,12 @@
 .user_image {
   height: 200px;
   width: 200px;
+}
+
+.u-name{
+  font-size: 50px;
+}
+
+.p-num{
+  align-self: self-end;
 }

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -35,7 +35,7 @@
   border: 2px solid #000;
   width: 70%;
   justify-content: space-between;
-  height: fit-content;
+  height:auto;
 }
 
 .post-preview {
@@ -57,10 +57,10 @@
   width: 200px;
 }
 
-.u-name{
+.u-name {
   font-size: 50px;
 }
 
-.p-num{
+.p-num {
   align-self: self-end;
 }

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -1,5 +1,4 @@
 <div class="u-container">
-<h1>Displays user posts</h1>
 <img class="u_image" src="<%= @user.photo ? @user.photo : 'https://images.unsplash.com/photo-1582567056798-7dc94989e56d?ixlib=rb-4.0.3&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=387&q=80' %>">
     <div class="u-info">
     <h3><%= link_to @user.name, @user %></h3>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,12 +1,12 @@
 <div>
 <div class="u-container">
 <%# <h1>Displays user info</h1> %>
-<img class="u_image" src="<%= @user.photo ? @user.photo : 'https://images.unsplash.com/photo-1582567056798-7dc94989e56d?ixlib=rb-4.0.3&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=387&q=80' %>">
+<img class="user_image" src="<%= @user.photo ? @user.photo : 'https://images.unsplash.com/photo-1582567056798-7dc94989e56d?ixlib=rb-4.0.3&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=387&q=80' %>">
     <div class="u-info">
-    <h3><%= link_to @user.name, @user %></h3>
+    <h3 class="u-name"><%= link_to @user.name, @user %></h3>
 
       <br>
-      Number of posts: <%= @user.posts_counter %>
+      <p class="p-num">Number of posts: <%= @user.posts_counter %></p>
     </div>
 </div>
  <div class="bio">
@@ -23,7 +23,7 @@
   </div>
 <% end %>
 
-  <% if Post.count > 3 %>
+  <div>
     <%= link_to "Show All Posts", user_posts_path(@user) %>
-  <% end %>
+  </div>
 </div>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,6 +1,6 @@
 <div>
 <div class="u-container">
-<h1>Displays user info</h1>
+<%# <h1>Displays user info</h1> %>
 <img class="u_image" src="<%= @user.photo ? @user.photo : 'https://images.unsplash.com/photo-1582567056798-7dc94989e56d?ixlib=rb-4.0.3&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=387&q=80' %>">
     <div class="u-info">
     <h3><%= link_to @user.name, @user %></h3>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -16,7 +16,9 @@
   <h2>Recent Posts</h2>
 <% @user.recent_posts.each do |post| %>
   <div class="post-preview">
+  <%= link_to user_post_path(@user, post) do %>
     <h3><%= post.title %></h3>
+    <% end %>
     <p><%= post.text %></p>
     <p>Number of comments: <%= post.comments.count %></p>
     <p>Number of likes: <%= post.likes_counter %></p>

--- a/spec/requests/posts_spec.rb
+++ b/spec/requests/posts_spec.rb
@@ -14,10 +14,10 @@ RSpec.describe PostsController, type: :request do
       expect(response).to render_template(:index)
     end
 
-    it 'includes the post titles in the response body' do
-      get user_posts_path(user)
-      expect(response.body).to include('Displays user posts')
-    end
+    # it 'includes the post titles in the response body' do
+    #   get user_posts_path(user)
+    #   expect(response.body).to include('Displays user posts')
+    # end
   end
 
   describe 'GET #show' do

--- a/spec/requests/users_spec.rb
+++ b/spec/requests/users_spec.rb
@@ -32,8 +32,8 @@ RSpec.describe UsersController, type: :request do
       expect(response).to render_template(:show)
     end
 
-    it 'If the response body includes correct placeholder text' do
-      expect(response.body).to include('Displays user info')
-    end
+    # it 'If the response body includes correct placeholder text' do
+    #   expect(response.body).to include('Displays user info')
+    # end
   end
 end

--- a/spec/views/user_show_spec.rb
+++ b/spec/views/user_show_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe 'User show page - ', type: :feature do
+RSpec.describe 'user_show', type: :feature do
   before :each do
     @user1 = User.create(
       name: 'David',
@@ -47,5 +47,10 @@ RSpec.describe 'User show page - ', type: :feature do
   it "When I click to see all posts, it redirects me to the user's post's index page." do
     click_link 'Show All Posts'
     expect(page).to have_current_path(user_posts_path(@user1))
+  end
+
+  it 'When I click on a post, it redirects me to that posts show page.' do
+    click_link "#{@post7.title}"
+    expect(page).to have_current_path(user_post_path(@user1, @post7))
   end
 end

--- a/spec/views/user_show_spec.rb
+++ b/spec/views/user_show_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe 'user_show', type: :feature do
   end
 
   it 'When I click on a post, it redirects me to that posts show page.' do
-    click_link "#{@post7.title}"
+    click_link @post7.title.to_s
     expect(page).to have_current_path(user_post_path(@user1, @post7))
   end
 end


### PR DESCRIPTION
> Solved the n=1 problem when fetching all posts and their comments for a user
Before
![Before fix](https://user-images.githubusercontent.com/30298520/233669875-71c66481-8a6d-481b-904e-971890b23089.png)
After
![After fix](https://user-images.githubusercontent.com/30298520/233669925-ac61a455-3631-4939-a3e0-8fa8600beeb8.png)

- Used Capybara to write integration tests for each view in the project.

> User index page:
- I can see the username of all other users.
- I can see the profile picture for each user.
- I can see the number of posts each user has written.
- When I click on a user, I am redirected to that user's show page.

> user show page:
- I can see the user's profile picture.
- I can see the user's username.
- I can see the number of posts the user has written.
- I can see the user's bio.
- I can see the user's first 3 posts.
- I can see a button that lets me view all of a user's posts.
- When I click a user's post, it redirects me to that post's show page.
- When I click to see all posts, it redirects me to the user's post's index page.

> User post index page:
- I can see the user's profile picture.
- I can see the user's username.
- I can see the number of posts the user has written.
- I can see a post's title.
- I can see some of the post's body.
- I can see the first comments on a post.
- I can see how many comments a post has.
- I can see how many likes a post has.
- I can see a section for pagination if there are more posts than fit on the view.
- When I click on a post, it redirects me to that post's show page.

> Post show page:

- I can see the post's title.
- I can see who wrote the post.
- I can see how many comments it has.
- I can see how many likes it has.
- I can see the post body.
- I can see the username of each commentor.
- I can see the comment each commentor left.